### PR TITLE
Added support for changing the BubbleCoachMark background and text color of the default TextView

### DIFF
--- a/cornedbeef/src/main/java/com/swiftkey/cornedbeef/BubbleCoachMark.java
+++ b/cornedbeef/src/main/java/com/swiftkey/cornedbeef/BubbleCoachMark.java
@@ -2,10 +2,12 @@ package com.swiftkey.cornedbeef;
 
 import android.content.Context;
 import android.graphics.Point;
+import android.graphics.PorterDuff;
 import android.view.LayoutInflater;
 import android.view.View;
 import android.view.ViewGroup.LayoutParams;
 import android.view.ViewGroup.MarginLayoutParams;
+import android.widget.ImageView;
 import android.widget.LinearLayout;
 import android.widget.PopupWindow;
 
@@ -32,12 +34,12 @@ public class BubbleCoachMark extends InternallyAnchoredCoachMark {
 
     private int mMinWidth;
     private int mArrowWidth;
-    private View mTopArrow;
-    private View mBottomArrow;
-    
+    private ImageView mTopArrow;
+    private ImageView mBottomArrow;
+
     public BubbleCoachMark(BubbleCoachMarkBuilder builder) {
         super(builder);
-        
+
         mTarget = builder.target;
         mShowBelowAnchor = builder.showBelowAnchor;
         mMinArrowMargin = (int) mContext.getResources()
@@ -51,15 +53,19 @@ public class BubbleCoachMark extends InternallyAnchoredCoachMark {
         LinearLayout contentHolder = (LinearLayout) view
                 .findViewById(R.id.coach_mark_content);
         contentHolder.addView(content);
-        
+
         // Measure the coach mark to get the minimum width (constrained by screen width and padding) 
         final int maxWidth = mContext.getResources()
                 .getDisplayMetrics().widthPixels - 2 * mPadding;
         view.measure(View.MeasureSpec.makeMeasureSpec(maxWidth, View.MeasureSpec.AT_MOST), 0);
         
         mMinWidth = view.getMeasuredWidth();
-        mTopArrow = view.findViewById(R.id.top_arrow);
-        mBottomArrow = view.findViewById(R.id.bottom_arrow);
+        mTopArrow = (ImageView) view.findViewById(R.id.top_arrow);
+        mBottomArrow = (ImageView) view.findViewById(R.id.bottom_arrow);
+
+        contentHolder.getBackground().setColorFilter(getBackgroundColor(), PorterDuff.Mode.SRC_ATOP);
+        mTopArrow.setColorFilter(getBackgroundColor());
+        mBottomArrow.setColorFilter(getBackgroundColor());
 
         // Ensure that content holder expands to fill the coach mark
         contentHolder.setLayoutParams(new LinearLayout.LayoutParams(
@@ -135,9 +141,9 @@ public class BubbleCoachMark extends InternallyAnchoredCoachMark {
         // Optional parameters with default values
         protected boolean showBelowAnchor = false;
         protected float target = 0.5f;
-        
-        public BubbleCoachMarkBuilder(Context context, View anchor, String message) {
-            super(context, anchor, message);
+
+        public BubbleCoachMarkBuilder(Context context, View anchor, String message, int textColor) {
+            super(context, anchor, message, textColor);
         }
 
         public BubbleCoachMarkBuilder(Context context, View anchor, View content) {

--- a/cornedbeef/src/main/java/com/swiftkey/cornedbeef/CoachMark.java
+++ b/cornedbeef/src/main/java/com/swiftkey/cornedbeef/CoachMark.java
@@ -50,6 +50,7 @@ public abstract class CoachMark {
     private final OnDismissListener mDismissListener;
     private final OnShowListener mShowListener;
     private final long mTimeout;
+    private final int mBackgroundColor;
     
     protected Rect mDisplayFrame;
     
@@ -63,6 +64,7 @@ public abstract class CoachMark {
         mPadding = (int) TypedValue.applyDimension(
                 TypedValue.COMPLEX_UNIT_DIP, builder.padding, 
                 mContext.getResources().getDisplayMetrics());
+        mBackgroundColor = builder.backgroundColor;
 
         // Create the coach mark view
         View view = createContentView(builder.content);
@@ -159,7 +161,14 @@ public abstract class CoachMark {
     public boolean isShowing() {
         return mPopup.isShowing();
     }
-    
+
+    /**
+     * Get the specified background color
+     */
+    protected int getBackgroundColor() {
+        return mBackgroundColor;
+    }
+
     /**
      * Get the visible display size of the window this view is attached to
      */
@@ -264,10 +273,11 @@ public abstract class CoachMark {
         protected int animationStyle = R.style.CoachMarkAnimation;
         protected View tokenView;
         protected OnShowListener showListener;
-        
-        public CoachMarkBuilder(Context context, View anchor, String message) {
+        protected int backgroundColor = Color.WHITE;
+
+        public CoachMarkBuilder(Context context, View anchor, String message, int textColor) {
             this(context, anchor, new TextView(context));
-            ((TextView) content).setTextColor(Color.WHITE);
+            ((TextView) content).setTextColor(textColor);
             ((TextView) content).setText(message);
         }
 
@@ -348,6 +358,17 @@ public abstract class CoachMark {
          */
         public CoachMarkBuilder setOnShowListener(OnShowListener listener) {
             this.showListener = listener;
+            return this;
+        }
+
+        /**
+         * Set the color of the coachmark background
+         *
+         * @param backgroundColor
+         *      the color to use for the background.
+         */
+        public CoachMarkBuilder setBackgroundColor(int backgroundColor) {
+            this.backgroundColor = backgroundColor;
             return this;
         }
 

--- a/cornedbeef/src/main/java/com/swiftkey/cornedbeef/HighlightCoachMark.java
+++ b/cornedbeef/src/main/java/com/swiftkey/cornedbeef/HighlightCoachMark.java
@@ -1,6 +1,7 @@
 package com.swiftkey.cornedbeef;
 
 import android.content.Context;
+import android.graphics.Color;
 import android.view.LayoutInflater;
 import android.view.View;
 import android.view.ViewGroup.LayoutParams;
@@ -45,11 +46,11 @@ public class HighlightCoachMark extends InternallyAnchoredCoachMark {
     public static class HighlightCoachMarkBuilder extends InternallyAnchoredCoachMarkBuilder {
 
         public HighlightCoachMarkBuilder(Context context, View anchor) {
-            super(context, anchor, new String());
+            super(context, anchor, "", Color.TRANSPARENT);
         }
 
-        public HighlightCoachMarkBuilder(Context context, View anchor, String message) {
-            super(context, anchor, message);
+        public HighlightCoachMarkBuilder(Context context, View anchor, String message, int textColor) {
+            super(context, anchor, message, textColor);
         }
 
         public HighlightCoachMarkBuilder(Context context, View anchor, View content) {

--- a/cornedbeef/src/main/java/com/swiftkey/cornedbeef/InternallyAnchoredCoachMark.java
+++ b/cornedbeef/src/main/java/com/swiftkey/cornedbeef/InternallyAnchoredCoachMark.java
@@ -35,8 +35,8 @@ public abstract class InternallyAnchoredCoachMark extends CoachMark {
 
     public abstract static class InternallyAnchoredCoachMarkBuilder extends CoachMarkBuilder {
 
-        public InternallyAnchoredCoachMarkBuilder(Context context, View anchor, String message) {
-            super(context, anchor, message);
+        public InternallyAnchoredCoachMarkBuilder(Context context, View anchor, String message, int textColor) {
+            super(context, anchor, message, textColor);
         }
 
         public InternallyAnchoredCoachMarkBuilder(Context context, View anchor, View content) {

--- a/cornedbeef/src/main/res/drawable/coach_mark_bubble.xml
+++ b/cornedbeef/src/main/res/drawable/coach_mark_bubble.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <shape xmlns:android="http://schemas.android.com/apk/res/android">
-    <solid android:color="@color/coach_mark_background"/>
+    <solid android:color="@android:color/white" />
     <corners android:radius="@dimen/coach_mark_border_radius"/>
 </shape>

--- a/cornedbeef/src/main/res/layout/coach_mark.xml
+++ b/cornedbeef/src/main/res/layout/coach_mark.xml
@@ -1,5 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <LinearLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:tools="http://schemas.android.com/tools"
     android:layout_width="wrap_content"
     android:layout_height="wrap_content"
     android:orientation="vertical">
@@ -8,10 +9,10 @@
         android:id="@+id/top_arrow"
         android:layout_width="15dp"
         android:layout_height="10dp"
-        android:tint="@color/coach_mark_background"
         android:scaleType="fitXY"
         android:src="@drawable/ic_pointy_mark_up"
-        android:visibility="gone" />
+        android:visibility="gone"
+        tools:ignore="ContentDescription" />
 
     <LinearLayout
         android:id="@+id/coach_mark_content"
@@ -25,8 +26,7 @@
         android:id="@+id/bottom_arrow"
         android:layout_width="15dp"
         android:layout_height="10dp"
-        android:tint="@color/coach_mark_background"
         android:scaleType="fitXY"
-        android:src="@drawable/ic_pointy_mark_down" />
-
+        android:src="@drawable/ic_pointy_mark_down"
+        tools:ignore="ContentDescription" />
 </LinearLayout>

--- a/cornedbeef/src/test/java/com/swiftkey/cornedbeef/InternallyAnchoredCoachMarkTestCase.java
+++ b/cornedbeef/src/test/java/com/swiftkey/cornedbeef/InternallyAnchoredCoachMarkTestCase.java
@@ -1,6 +1,7 @@
 package com.swiftkey.cornedbeef;
 
 import android.content.Context;
+import android.graphics.Color;
 import android.view.View;
 import android.widget.PopupWindow;
 
@@ -9,9 +10,9 @@ import org.junit.runner.RunWith;
 import org.robolectric.RobolectricTestRunner;
 import org.robolectric.RuntimeEnvironment;
 
+import static com.swiftkey.cornedbeef.CoachMark.CoachMarkDimens;
 import static org.junit.Assert.assertEquals;
 import static org.mockito.Mockito.mock;
-import static com.swiftkey.cornedbeef.CoachMark.CoachMarkDimens;
 
 @RunWith(RobolectricTestRunner.class)
 public class InternallyAnchoredCoachMarkTestCase {
@@ -76,7 +77,7 @@ public class InternallyAnchoredCoachMarkTestCase {
         public static class TestInternallyAnchoredCoachMarkBuilder extends InternallyAnchoredCoachMarkBuilder {
            
             public TestInternallyAnchoredCoachMarkBuilder(Context context, View anchor, String message) {
-                super(context, anchor, message);
+                super(context, anchor, message, Color.BLACK);
             }
 
             @Override

--- a/integrationtest/src/androidTest/java/com/swiftkey/cornedbeef/BubbleCoachMarkTestCase.java
+++ b/integrationtest/src/androidTest/java/com/swiftkey/cornedbeef/BubbleCoachMarkTestCase.java
@@ -1,5 +1,6 @@
 package com.swiftkey.cornedbeef;
 
+import android.graphics.Color;
 import android.graphics.Rect;
 import android.os.SystemClock;
 import android.test.ActivityInstrumentationTestCase2;
@@ -47,7 +48,9 @@ public class
         getInstrumentation().waitForIdleSync();
         waitUntilStatusBarHidden();
         
-        mCoachMark = new BubbleCoachMark.BubbleCoachMarkBuilder(mActivity, mAnchor, "spam spam spam").build();
+        mCoachMark = new BubbleCoachMark.BubbleCoachMarkBuilder(mActivity, mAnchor, "spam spam spam", Color.WHITE)
+                .setBackgroundColor(Color.BLUE)
+                .build();
     }
     
     public void tearDown() throws Exception {
@@ -125,7 +128,7 @@ public class
         final View topArrow;
         final View bottomArrow;
         mCoachMark = new BubbleCoachMark.BubbleCoachMarkBuilder(
-                mActivity, mAnchor, "spam spam spam")
+                mActivity, mAnchor, "spam spam spam", Color.BLACK)
                 .setShowBelowAnchor(true)
                 .build();
 
@@ -157,7 +160,7 @@ public class
      */
     public void testShowPopupTargetLeft() {
         mCoachMark = new BubbleCoachMark.BubbleCoachMarkBuilder(
-                mActivity, mAnchor, "spam spam spam").setTargetOffset(0.25f).build();
+                mActivity, mAnchor, "spam spam spam", Color.BLACK).setTargetOffset(0.25f).build();
         
         showCoachMark(mCoachMark);
         
@@ -173,7 +176,7 @@ public class
      */
     public void testShowPopupTargetRight() {
         mCoachMark = new BubbleCoachMark.BubbleCoachMarkBuilder(
-                mActivity, mAnchor, "spam spam spam").setTargetOffset(0.75f).build();
+                mActivity, mAnchor, "spam spam spam", Color.BLACK).setTargetOffset(0.75f).build();
         
         showCoachMark(mCoachMark);
         
@@ -261,7 +264,8 @@ public class
                 mAnchor,
                 "This is a long message. We're using it to verify that when the popup content is" + 
                 " wrapped over multiple lines, the popup is still positioned above the anchor." + 
-                "Here is some more text to make sure that this the text spans multiple lines").build();
+                "Here is some more text to make sure that this the text spans multiple lines",
+                Color.BLACK).build();
   
         moveAnchor(0, 600);
         showCoachMark(mCoachMark);
@@ -286,7 +290,7 @@ public class
         int[] anchorPos = new int[2];
         int[] contentPos = new int[2];
         mCoachMark = new BubbleCoachMark.BubbleCoachMarkBuilder(
-                mActivity, mAnchor, "spam spam spam")
+                mActivity, mAnchor, "spam spam spam", Color.BLACK)
                 .setInternalAnchor(0.25f, 0.5f, 0.5f, 0.5f).build();
         
         moveAnchor(0, 200);
@@ -315,7 +319,7 @@ public class
         int[] anchorPos = new int[2];
         int[] contentPos = new int[2];
         mCoachMark = new BubbleCoachMark.BubbleCoachMarkBuilder(
-                mActivity, mAnchor, "spam spam spam")
+                mActivity, mAnchor, "spam spam spam", Color.BLACK)
                 .setTargetOffset(0.25f)
                 .setInternalAnchor(0.5f, 0.5f, 0.5f, 0.5f)
                 .build();
@@ -344,7 +348,8 @@ public class
                 mAnchor, 
                 "This is a long coach mark, to which padding will be applied." +
                 "For testing purposes it is important that this coach mark is" +
-                " wider than the width of the screen, otherwise this will fail")
+                " wider than the width of the screen, otherwise this will fail",
+                Color.BLACK)
                 .setPadding(10).build();
         
         showCoachMark(mCoachMark);

--- a/integrationtest/src/androidTest/java/com/swiftkey/cornedbeef/CoachMarkTestCase.java
+++ b/integrationtest/src/androidTest/java/com/swiftkey/cornedbeef/CoachMarkTestCase.java
@@ -175,7 +175,7 @@ public class CoachMarkTestCase extends ActivityInstrumentationTestCase2<SpamActi
         public static class TestCoachMarkBuilder extends CoachMarkBuilder {
 
             public TestCoachMarkBuilder(Context context, View anchor, String text) {
-                super(context, anchor, text);
+                super(context, anchor, text, Color.WHITE);
                 content.setBackgroundDrawable(new ColorDrawable(Color.BLACK));
             }
 

--- a/integrationtest/src/main/java/com/swiftkey/cornedbeef/test/SpamActivity.java
+++ b/integrationtest/src/main/java/com/swiftkey/cornedbeef/test/SpamActivity.java
@@ -2,6 +2,7 @@ package com.swiftkey.cornedbeef.test;
 
 import android.app.Activity;
 import android.content.Context;
+import android.graphics.Color;
 import android.os.Bundle;
 import android.view.View;
 import android.view.Window;
@@ -25,7 +26,7 @@ public class SpamActivity extends Activity {
         final Context context = getApplicationContext();
         final View view = findViewById(R.id.hello_world);
 
-        mBubbleCoachMark = new BubbleCoachMark.BubbleCoachMarkBuilder(context, view, "This is a coach mark!")
+        mBubbleCoachMark = new BubbleCoachMark.BubbleCoachMarkBuilder(context, view, "This is a coach mark!", Color.BLACK)
                 .setTargetOffset(0.25f)
                 .setShowBelowAnchor(true)
                 .setPadding(10)

--- a/integrationtest/src/main/res/layout/coach_mark_test_activity.xml
+++ b/integrationtest/src/main/res/layout/coach_mark_test_activity.xml
@@ -2,7 +2,6 @@
 <LinearLayout xmlns:android="http://schemas.android.com/apk/res/android"
     android:layout_width="match_parent"
     android:layout_height="match_parent"
-    android:background="@android:color/white"
     android:orientation="vertical" >
     
     <View 


### PR DESCRIPTION
@lachiemurray I'm currently setting the background color on `CoachMarkBuilder` because the method `createContentView` gets called immediately on the `CoachMark` constructor.

Could we delay the View initialisation to the `show()` method?
