### PR TITLE
TUBE-66 - Allow us to have punch hole coachmarks that move horizontally from the start to the end of a view

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,6 +30,19 @@ A translucent layer onto the particular view and "Punch Hole" for given child vi
 ./gradlew clean build test connectedAndroidTest
 ```
 
+### Proguard rules
+
+It's safe to use either `getDefaultProguardFile('proguard-android.txt')` or `getDefaultProguardFile('proguard-android-optimize.txt')`. CornedBeef uses the Android animator APIs which require reflection and can make some methods appear to be deadcode to proguard.
+
+Use the following explicit rule to make sure these APIs remain if you are experiencing problems with the PunchHoleCoachMark animations:
+
+```
+-keepclassmembers public class * extends android.view.View {
+   void set*(***);
+   *** get*();
+}
+```
+
 ## License
 
     Licensed under the Apache License, Version 2.0 (the "License");

--- a/cornedbeef/build.gradle
+++ b/cornedbeef/build.gradle
@@ -13,7 +13,7 @@ android {
         minSdkVersion 9
         targetSdkVersion 22
         versionCode 2
-        versionName "1.1.0"
+        versionName "1.1.1"
     }
     buildTypes {
         release {

--- a/cornedbeef/src/main/java/com/swiftkey/cornedbeef/CoachMark.java
+++ b/cornedbeef/src/main/java/com/swiftkey/cornedbeef/CoachMark.java
@@ -51,7 +51,7 @@ public abstract class CoachMark {
     private final OnPreDrawListener mPreDrawListener;
     private final OnDismissListener mDismissListener;
     private final OnShowListener mShowListener;
-    final long mTimeoutInMs;
+    private final long mTimeoutInMs;
 
     protected Rect mDisplayFrame;
     

--- a/cornedbeef/src/main/java/com/swiftkey/cornedbeef/CoachMark.java
+++ b/cornedbeef/src/main/java/com/swiftkey/cornedbeef/CoachMark.java
@@ -51,7 +51,7 @@ public abstract class CoachMark {
     private final OnPreDrawListener mPreDrawListener;
     private final OnDismissListener mDismissListener;
     private final OnShowListener mShowListener;
-    private final long mTimeoutInMs;
+    final long mTimeoutInMs;
 
     protected Rect mDisplayFrame;
     

--- a/cornedbeef/src/main/java/com/swiftkey/cornedbeef/CoachMark.java
+++ b/cornedbeef/src/main/java/com/swiftkey/cornedbeef/CoachMark.java
@@ -5,8 +5,8 @@ import android.graphics.Color;
 import android.graphics.Point;
 import android.graphics.Rect;
 import android.graphics.drawable.ColorDrawable;
-import android.support.annotation.AnimRes;
 import android.support.annotation.LayoutRes;
+import android.support.annotation.StyleRes;
 import android.util.TypedValue;
 import android.view.Gravity;
 import android.view.LayoutInflater;
@@ -337,9 +337,9 @@ public abstract class CoachMark {
          * Set which animation will be used when displaying/hiding the coach mark
          * 
          * @param animationStyle
-         *      the resource ID of the animation to be shown
+         *      the resource ID of the Style to be used for showing and hiding the coach mark
          */
-        public CoachMarkBuilder setAnimation(@AnimRes int animationStyle) {
+        public CoachMarkBuilder setAnimation(@StyleRes int animationStyle) {
             this.animationStyle = animationStyle;
             return this;
         }

--- a/cornedbeef/src/main/java/com/swiftkey/cornedbeef/PunchHoleCoachMark.java
+++ b/cornedbeef/src/main/java/com/swiftkey/cornedbeef/PunchHoleCoachMark.java
@@ -118,9 +118,10 @@ public class PunchHoleCoachMark extends InternallyAnchoredCoachMark {
     }
 
     /**
-     * Move the punch hole from left to right of the target view, unless the
-     * width of the target view is smaller than the diameter of the punch hole
-     * in which case the circle will be centered and the animation is pointless.
+     * Move the punch hole from start to end of the target view and back from
+     * end to start, unless the width of the target view is smaller than the
+     * diameter of the punch hole in which case the circle will be centered and
+     * the animation is pointless.
      */
     @TargetApi(Build.VERSION_CODES.HONEYCOMB)
     private void animateHorizontalTranslation() {

--- a/cornedbeef/src/main/java/com/swiftkey/cornedbeef/PunchHoleView.java
+++ b/cornedbeef/src/main/java/com/swiftkey/cornedbeef/PunchHoleView.java
@@ -86,6 +86,8 @@ public class PunchHoleView extends LinearLayout {
                 centerX - (int) radius, centerY - (int) radius,
                 centerX + (int) radius, centerY + (int) radius);
 
+        postInvalidate();
+
         return true;
     }
 
@@ -100,6 +102,7 @@ public class PunchHoleView extends LinearLayout {
     public boolean setCircleCenterX(int centerX) {
         if (this.mCircleCenterX != centerX) {
             this.mCircleCenterX = centerX;
+            postInvalidate();
             return true;
         } else {
             return false;
@@ -115,6 +118,7 @@ public class PunchHoleView extends LinearLayout {
     private boolean setCircleCenterY(int centerY) {
         if (this.mCircleCenterY != centerY) {
             this.mCircleCenterY = centerY;
+            postInvalidate();
             return true;
         } else {
             return false;
@@ -130,6 +134,7 @@ public class PunchHoleView extends LinearLayout {
     private boolean setCircleRadius(float radius) {
         if (this.mCircleRadius != radius) {
             this.mCircleRadius = radius;
+            postInvalidate();
             return true;
         } else {
             return false;

--- a/cornedbeef/src/main/java/com/swiftkey/cornedbeef/PunchHoleView.java
+++ b/cornedbeef/src/main/java/com/swiftkey/cornedbeef/PunchHoleView.java
@@ -90,12 +90,14 @@ public class PunchHoleView extends LinearLayout {
     }
 
     /**
-     * Set the punch hole's x coordinate
+     * Set the punch hole's x coordinate.
+     *
+     * This needs to be public to do the horizontal translation animation.
      *
      * @param centerX circle's x coordinate
      * @return true if value is changed
      */
-    private boolean setCircleCenterX(int centerX) {
+    public boolean setCircleCenterX(int centerX) {
         if (this.mCircleCenterX != centerX) {
             this.mCircleCenterX = centerX;
             return true;

--- a/integrationtest/src/androidTest/java/com/swiftkey/cornedbeef/PunchHoleCoachMarkTestCase.java
+++ b/integrationtest/src/androidTest/java/com/swiftkey/cornedbeef/PunchHoleCoachMarkTestCase.java
@@ -303,7 +303,7 @@ public class PunchHoleCoachMarkTestCase extends ActivityInstrumentationTestCase2
     private void setupCoachmark(final boolean animation) {
         mCoachMark = new PunchHoleCoachMark.PunchHoleCoachMarkBuilder(mActivity, mAnchor, mTextView)
                 .setTargetView(mTargetView)
-                .setHorizontalTranslation(animation)
+                .setHorizontalTranslationDuration(animation ? 1000 : 0)
                 .setOnTargetClickListener(mMockTargetClickListener)
                 .setOnGlobalClickListener(mMockCoachMarkClickListener)
                 .setOverlayColor(OVERLAY_COLOR)

--- a/integrationtest/src/androidTest/java/com/swiftkey/cornedbeef/PunchHoleCoachMarkTestCase.java
+++ b/integrationtest/src/androidTest/java/com/swiftkey/cornedbeef/PunchHoleCoachMarkTestCase.java
@@ -1,6 +1,7 @@
 package com.swiftkey.cornedbeef;
 
 import android.graphics.Color;
+import android.graphics.drawable.ColorDrawable;
 import android.test.ActivityInstrumentationTestCase2;
 import android.test.TouchUtils;
 import android.test.ViewAsserts;
@@ -37,6 +38,7 @@ public class PunchHoleCoachMarkTestCase extends ActivityInstrumentationTestCase2
 
     private TextView mTextView;
     private static final String MESSAGE = "spam spam spam";
+    private final int OVERLAY_COLOR = Color.BLACK;
 
     public PunchHoleCoachMarkTestCase() {
         super(SpamActivity.class);
@@ -90,6 +92,13 @@ public class PunchHoleCoachMarkTestCase extends ActivityInstrumentationTestCase2
     public void testViewsCreatedAndVisible_animation() {
         setupCoachmark(true);
         checkViewsCreatedAndVisible();
+    }
+
+    public void testOverlayCorrectColor() {
+        setupCoachmark(false);
+        final View container = mCoachMark.getContentView();
+        int color = ((ColorDrawable) container.getBackground()).getColor();
+        assertEquals(OVERLAY_COLOR, color);
     }
 
     /**
@@ -297,6 +306,7 @@ public class PunchHoleCoachMarkTestCase extends ActivityInstrumentationTestCase2
                 .setHorizontalTranslation(animation)
                 .setOnTargetClickListener(mMockTargetClickListener)
                 .setOnGlobalClickListener(mMockCoachMarkClickListener)
+                .setOverlayColor(OVERLAY_COLOR)
                 .build();
     }
 }

--- a/integrationtest/src/androidTest/java/com/swiftkey/cornedbeef/PunchHoleCoachMarkTestCase.java
+++ b/integrationtest/src/androidTest/java/com/swiftkey/cornedbeef/PunchHoleCoachMarkTestCase.java
@@ -1,5 +1,6 @@
 package com.swiftkey.cornedbeef;
 
+import android.graphics.Color;
 import android.test.ActivityInstrumentationTestCase2;
 import android.test.TouchUtils;
 import android.test.ViewAsserts;
@@ -65,11 +66,7 @@ public class PunchHoleCoachMarkTestCase extends ActivityInstrumentationTestCase2
         mTextView = (TextView) LayoutInflater.from(mActivity)
                 .inflate(R.layout.sample_customised_punchhole_content, null);
         mTextView.setText(MESSAGE);
-        mCoachMark = new PunchHoleCoachMark.PunchHoleCoachMarkBuilder(mActivity, mAnchor, mTextView)
-                .setTargetView(mTargetView)
-                .setOnTargetClickListener(mMockTargetClickListener)
-                .setOnGlobalClickListener(mMockCoachMarkClickListener)
-                .build();
+        mTextView.setTextColor(Color.WHITE); // to make visual debugging easier
     }
 
     public void tearDown() throws Exception {
@@ -85,10 +82,20 @@ public class PunchHoleCoachMarkTestCase extends ActivityInstrumentationTestCase2
         super.tearDown();
     }
 
+    public void testViewsCreatedAndVisible_noAnimation() {
+        setupCoachmark(false);
+        checkViewsCreatedAndVisible();
+    }
+
+    public void testViewsCreatedAndVisible_animation() {
+        setupCoachmark(true);
+        checkViewsCreatedAndVisible();
+    }
+
     /**
      * Test the view creation and visibility.
      */
-    public void testViewsCreatedAndVisible() {
+    private void checkViewsCreatedAndVisible() {
         showCoachMark(getInstrumentation(), mCoachMark);
 
         final View container = mCoachMark.getContentView();
@@ -107,10 +114,20 @@ public class PunchHoleCoachMarkTestCase extends ActivityInstrumentationTestCase2
         assertEquals(MESSAGE, mTextView.getText().toString());
     }
 
+    public void testTargetClick_noAnimation() {
+        setupCoachmark(false);
+        checkTargetClick();
+    }
+
+    public void testTargetClick_animation() {
+        setupCoachmark(true);
+        checkTargetClick();
+    }
+
     /**
      * Test the target's click listener
      */
-    public void testTargetClick() {
+    private void checkTargetClick() {
         showCoachMark(getInstrumentation(), mCoachMark);
 
         final View container = mCoachMark.getContentView();
@@ -123,10 +140,20 @@ public class PunchHoleCoachMarkTestCase extends ActivityInstrumentationTestCase2
         verify(mMockCoachMarkClickListener, never()).onClick(container);
     }
 
+    public void testCoachMarkClick_noAnimation() {
+        setupCoachmark(false);
+        checkCoachMarkClick();
+    }
+
+    public void testCoachMarkClick_animation() {
+        setupCoachmark(true);
+        checkCoachMarkClick();
+    }
+
     /**
      * Test the coachmark's click listener
      */
-    public void testCoachMarkClick() {
+    private void checkCoachMarkClick() {
         showCoachMark(getInstrumentation(), mCoachMark);
 
         final View container = mCoachMark.getContentView();
@@ -144,10 +171,29 @@ public class PunchHoleCoachMarkTestCase extends ActivityInstrumentationTestCase2
         verify(mMockCoachMarkClickListener, times(2)).onClick(container);
     }
 
+    public void testCircleIsOverlayed_noAnimation() {
+        setupCoachmark(false);
+        checkCircleIsOverlayed(false);
+    }
+
+    public void testCircleIsOverlayed_animationCannotHappen() {
+        setupCoachmark(true);
+        // the target view is too small for the animation to happen so we just
+        // centre the punch hole on the target view
+        checkCircleIsOverlayed(false);
+    }
+
+    public void testCircleIsOverlayed_animationCanHappen() {
+        mTargetView = mActivity.findViewById(R.id.coach_mark_test_target_wide);
+        setupCoachmark(true);
+        // the target view is wide enough for the animation to happen
+        checkCircleIsOverlayed(true);
+    }
+
     /**
      * Test the location of punch hole to target view.
      */
-    public void testCircleIsOverlayed() {
+    private void checkCircleIsOverlayed(final boolean animationShouldHappen) {
         showCoachMark(getInstrumentation(), mCoachMark);
 
         final PunchHoleView container = (PunchHoleView) mCoachMark.getContentView();
@@ -164,17 +210,36 @@ public class PunchHoleCoachMarkTestCase extends ActivityInstrumentationTestCase2
         final int width = mTargetView.getWidth();
         final int height = mTargetView.getHeight();
 
-        final int expectedCircleX = targetScreenLoc[0] + (width / 2) - containerScreenLoc[0];
-        final int expectedCircleY = targetScreenLoc[1] + (height / 2) - containerScreenLoc[1];
         final float expectedCircleRadius = (height + diameterGap) / 2;
 
-        assertFalse(container.setCircle(expectedCircleX, expectedCircleY, expectedCircleRadius));
+        final int expectedCircleStartOffsetX = animationShouldHappen
+                ?  targetScreenLoc[0] + (int) expectedCircleRadius
+                : width / 2;
+        final int expectedCircleStartX = targetScreenLoc[0] + expectedCircleStartOffsetX - containerScreenLoc[0];
+        final int expectedCircleStartY = targetScreenLoc[1] + (height / 2) - containerScreenLoc[1];
+
+        // When the animation happens, the circle should not be in the start
+        // position. Unfortunately we can't test that it ever was in the right
+        // start position in this case as it starts moving when it's shown.
+        assertEquals(
+                animationShouldHappen,
+                container.setCircle(expectedCircleStartX, expectedCircleStartY, expectedCircleRadius));
+    }
+
+    public void testMessageLocatedAbove_noAnimation() {
+        setupCoachmark(false);
+        checkMessageLocatedAbove();
+    }
+
+    public void testMessageLocatedAbove_animation() {
+        setupCoachmark(true);
+        checkMessageLocatedAbove();
     }
 
     /**
      * Test that the message is shown above when target view located in bottom side.
      */
-    public void testMessageLoacatedAbove() {
+    private void checkMessageLocatedAbove() {
         showCoachMark(getInstrumentation(), mCoachMark);
 
         final PunchHoleView container = (PunchHoleView) mCoachMark.getContentView();
@@ -194,10 +259,20 @@ public class PunchHoleCoachMarkTestCase extends ActivityInstrumentationTestCase2
         assertTrue(relativeTextViewX < (height / 2));
     }
 
+    public void testMessageLocatedBelow_noAnimation() {
+        setupCoachmark(false);
+        checkMessageLocatedBelow();
+    }
+
+    public void testMessageLocatedBelow_animation() {
+        setupCoachmark(true);
+        checkMessageLocatedBelow();
+    }
+
     /**
      * Test that the message is shown below when target view located in top side.
      */
-    public void testMessageLoacatedBelow() {
+    private void checkMessageLocatedBelow() {
         showCoachMark(getInstrumentation(), mCoachMark);
 
         final PunchHoleView container = (PunchHoleView) mCoachMark.getContentView();
@@ -214,5 +289,14 @@ public class PunchHoleCoachMarkTestCase extends ActivityInstrumentationTestCase2
         final int relativeTextViewX = textScreenLoc[1] - containerScreenLoc[1] + mTextView.getHeight() / 2;
 
         assertTrue(relativeTextViewX > (height / 2));
+    }
+
+    private void setupCoachmark(final boolean animation) {
+        mCoachMark = new PunchHoleCoachMark.PunchHoleCoachMarkBuilder(mActivity, mAnchor, mTextView)
+                .setTargetView(mTargetView)
+                .setHorizontalTranslation(animation)
+                .setOnTargetClickListener(mMockTargetClickListener)
+                .setOnGlobalClickListener(mMockCoachMarkClickListener)
+                .build();
     }
 }

--- a/integrationtest/src/main/res/layout/coach_mark_test_activity.xml
+++ b/integrationtest/src/main/res/layout/coach_mark_test_activity.xml
@@ -25,6 +25,14 @@
             android:layout_margin="10dp"
             android:background="@android:color/black"/>
 
+        <View
+            android:id="@+id/coach_mark_test_target_wide"
+            android:layout_width="100dp"
+            android:layout_height="20dp"
+            android:layout_gravity="center_vertical"
+            android:layout_margin="10dp"
+            android:background="@android:color/black"/>
+
     </LinearLayout>
 
 </LinearLayout>


### PR DESCRIPTION
This should allow us to do the first use Swiftmoji coachmark, that shows a punch hole moving from the start to the end of the emoji bar.

I won't merge this until I get the final specs for that coachmark, since this may not be exactly what we need.

The punch hole coachmark can take a new parameter that says if the hole should be animated. I've taken into account LTR/RTL and that some views are smaller than the punch hole and therefore we can't do this animation on them.

Can @lachiemurray and @ojj11 have a look? Thanks!

This is now TUBE-66.