### PR TITLE
Fix BubbleCoachMark arrow placement in RTL mode

### DIFF
--- a/cornedbeef/src/main/res/layout/bubble_coach_mark.xml
+++ b/cornedbeef/src/main/res/layout/bubble_coach_mark.xml
@@ -2,7 +2,8 @@
 <LinearLayout xmlns:android="http://schemas.android.com/apk/res/android"
     android:layout_width="wrap_content"
     android:layout_height="wrap_content"
-    android:orientation="vertical">
+    android:orientation="vertical"
+    android:gravity="left|top">
 
     <ImageView
         android:id="@+id/top_arrow"


### PR DESCRIPTION
If the BubbleCoachMark is used in RTL mode, the arrow is placed on the right as the default gravity for linear layout is start|top which is on the right. This can be reproduced by adding the "supportsRtl:true" property to the application element of the integrationtest AndroidManifest.xml. See before and after screenshots below

For additional information, please contact Sara Metz (sametz@microsoft.com)

Without the fix:
![rtl_before](https://cloud.githubusercontent.com/assets/25468140/22490428/21f18470-e7d2-11e6-8c9b-6107c7a00cf0.png)

With the fix:
![rtl_after](https://cloud.githubusercontent.com/assets/25468140/22490429/21f1cc46-e7d2-11e6-801a-b8ac8a3d03f3.png)
