### PR TITLE
Fixing styles to work with AAPT2

### DIFF
--- a/cornedbeef/src/main/res/values/styles.xml
+++ b/cornedbeef/src/main/res/values/styles.xml
@@ -2,8 +2,8 @@
 
     <!-- CoachMark animation -->
     <style name="CoachMarkAnimation">
-        <item name="@android:windowEnterAnimation">@anim/coach_mark_show</item>
-        <item name="@android:windowExitAnimation">@anim/coach_mark_hide</item>
+        <item name="android:windowEnterAnimation">@anim/coach_mark_show</item>
+        <item name="android:windowExitAnimation">@anim/coach_mark_hide</item>
     </style>
 
 </resources>


### PR DESCRIPTION
The new AAPT does not like the "@" symbol before android on an item definition. This causes the library to fail the build on Android Studio 3.0. Removing the "@" fixes the issue.