### PR TITLE
Add padding option to PunchHoleCoachmark

### DIFF
--- a/cornedbeef/src/main/java/com/swiftkey/cornedbeef/CoachMark.java
+++ b/cornedbeef/src/main/java/com/swiftkey/cornedbeef/CoachMark.java
@@ -392,8 +392,7 @@ public abstract class CoachMark {
          * Set how much padding there should be between the left and right edges
          * of the coach mark and the screen
          * 
-         * @param padding
-         *      the amount of left/right padding in px
+         * @param padding the amount of left/right padding in density-independent pixels (dip)
          */
         public CoachMarkBuilder setPadding(int padding) {
             this.padding = padding;
@@ -404,7 +403,7 @@ public abstract class CoachMark {
          * Set an {@link CoachMark.OnDismissListener} to be called when the
          * coach mark is dismissed
          * 
-         * @param listener
+         * @param listener the onDismissListener
          */
         public CoachMarkBuilder setOnDismissListener(OnDismissListener listener) {
             this.dismissListener = listener;

--- a/cornedbeef/src/main/java/com/swiftkey/cornedbeef/PunchHoleCoachMark.java
+++ b/cornedbeef/src/main/java/com/swiftkey/cornedbeef/PunchHoleCoachMark.java
@@ -9,6 +9,7 @@ import android.content.res.Configuration;
 import android.os.Build;
 import android.support.annotation.IntDef;
 import android.support.annotation.LayoutRes;
+import android.util.TypedValue;
 import android.view.LayoutInflater;
 import android.view.View;
 import android.view.ViewGroup.LayoutParams;
@@ -48,6 +49,7 @@ public class PunchHoleCoachMark extends InternallyAnchoredCoachMark {
     private final float mGap;
     private final long mHorizontalTranslationDuration;
     private final int mContentPosition;
+    private final int mPunchHolePadding;
 
     private final View mTargetView;
     private final int[] mTargetViewLoc = new int[2];
@@ -76,6 +78,11 @@ public class PunchHoleCoachMark extends InternallyAnchoredCoachMark {
         mHorizontalTranslationDuration = builder.horizontalAnimationDuration;
 
         mContentPosition = builder.contentPositioning;
+
+        mPunchHolePadding = (int) TypedValue.applyDimension(
+                TypedValue.COMPLEX_UNIT_DIP,
+                builder.punchHolePadding,
+                mContext.getResources().getDisplayMetrics());
     }
 
     @Override
@@ -109,7 +116,7 @@ public class PunchHoleCoachMark extends InternallyAnchoredCoachMark {
 
         mTargetView.getLocationOnScreen(mTargetViewLoc);
         mAnchor.getLocationOnScreen(mAnchorViewLoc);
-        mRelCircleRadius = (mTargetView.getHeight() + mGap) / 2;
+        mRelCircleRadius = Math.max(((mTargetView.getHeight() + mGap) / 2) + mPunchHolePadding, 0f);
 
         // If the coachmark has an horizontal translation animation, draw the
         // circle on the start of the target view (it will move to the end).
@@ -231,6 +238,8 @@ public class PunchHoleCoachMark extends InternallyAnchoredCoachMark {
         private int contentWidth = MATCH_PARENT;
         private int contentHeight = WRAP_CONTENT;
 
+        private int punchHolePadding = 0;
+
         public PunchHoleCoachMarkBuilder(Context context, View anchor, String message) {
             super(context, anchor, message);
         }
@@ -317,6 +326,20 @@ public class PunchHoleCoachMark extends InternallyAnchoredCoachMark {
             }
 
             this.horizontalAnimationDuration = horizontalDuration;
+            return this;
+        }
+
+        /**
+         * Set the padding for the punch hole around the anchor view in density-independent
+         * pixels (dip).
+         *
+         * A positive value will increase the punch hole's radius and a negative value will
+         * decrease the punch hole's radius.
+         *
+         * @param punchHolePadding the padding to be added to the punch hole in dip
+         */
+        public PunchHoleCoachMarkBuilder setPunchHolePadding(final int punchHolePadding) {
+            this.punchHolePadding = punchHolePadding;
             return this;
         }
 

--- a/integrationtest/src/androidTest/java/com/swiftkey/cornedbeef/PunchHoleCoachMarkTestCase.java
+++ b/integrationtest/src/androidTest/java/com/swiftkey/cornedbeef/PunchHoleCoachMarkTestCase.java
@@ -6,6 +6,7 @@ import android.graphics.drawable.ColorDrawable;
 import android.test.ActivityInstrumentationTestCase2;
 import android.test.TouchUtils;
 import android.test.ViewAsserts;
+import android.util.TypedValue;
 import android.view.LayoutInflater;
 import android.view.View;
 import android.view.WindowManager;
@@ -43,6 +44,7 @@ public class PunchHoleCoachMarkTestCase extends ActivityInstrumentationTestCase2
 
     private TextView mTextView;
     private static final String MESSAGE = "spam spam spam";
+    private static final int PADDING = 10;
     private final int OVERLAY_COLOR = Color.BLACK;
 
     public PunchHoleCoachMarkTestCase() {
@@ -224,7 +226,11 @@ public class PunchHoleCoachMarkTestCase extends ActivityInstrumentationTestCase2
         final int width = mTargetView.getWidth();
         final int height = mTargetView.getHeight();
 
-        final float expectedCircleRadius = (height + diameterGap) / 2;
+        final int expectedPadding = (int) TypedValue.applyDimension(
+                TypedValue.COMPLEX_UNIT_DIP,
+                PADDING,
+                mActivity.getResources().getDisplayMetrics());
+        final float expectedCircleRadius = ((height + diameterGap) / 2) + expectedPadding;
 
         final int expectedCircleStartOffsetX = animationShouldHappen
                 ?  targetScreenLoc[0] + (int) expectedCircleRadius
@@ -333,6 +339,7 @@ public class PunchHoleCoachMarkTestCase extends ActivityInstrumentationTestCase2
                 .setOnGlobalClickListener(mMockCoachMarkClickListener)
                 .setOverlayColor(OVERLAY_COLOR)
                 .setContentLayoutParams(MATCH_PARENT, MATCH_PARENT, POSITION_CONTENT_AUTOMATICALLY)
+                .setPunchHolePadding(PADDING)
                 .build();
     }
 }

--- a/integrationtest/src/main/java/com/swiftkey/cornedbeef/test/SpamActivity.java
+++ b/integrationtest/src/main/java/com/swiftkey/cornedbeef/test/SpamActivity.java
@@ -79,6 +79,7 @@ public class SpamActivity extends Activity {
                         Toast.makeText(context, "The coach mark clicked!", Toast.LENGTH_SHORT).show();
                     }
                 })
+                .setPunchHolePadding(5)
                 .setTimeout(0)
                 .build();
 


### PR DESCRIPTION
Add an option for padding around the punch hole of a `PunchHoleCoachmark`. Currently the punch hole is set only based on the height of the target view so this should provide a bit of flexibility. 

Automated tests and `SpamActivity` updated.