### PR TITLE
Don't crash when trying to hide an already hidden window

### DIFF
--- a/cornedbeef/src/main/java/com/swiftkey/cornedbeef/CoachMark.java
+++ b/cornedbeef/src/main/java/com/swiftkey/cornedbeef/CoachMark.java
@@ -166,7 +166,12 @@ public abstract class CoachMark {
                         if (mTimeoutListener != null) {
                             mTimeoutListener.onTimeout();
                         }
-                        dismiss();
+                        try {
+                            dismiss();
+                        } catch(IllegalArgumentException e) {
+                            // Closes #19 - popup has already been removed outside of CornedBeef's
+                            // control
+                        }
                     }
                 }
             };
@@ -189,6 +194,7 @@ public abstract class CoachMark {
         mAnchor.destroyDrawingCache();
         mAnchor.getViewTreeObserver().removeOnPreDrawListener(mPreDrawListener);
         mPopup.getContentView().removeCallbacks(mTimeoutDismissRunnable);
+
         mPopup.dismiss();
 
         if (mDismissListener != null) {


### PR DESCRIPTION
This is crashing for us internally on a JUnit test run because we're trying to hide a window that's already hidden.

I'm hoping this will fix the problem but I haven't been able to reproduce on my device. If this doesn't work then I think the solution is to catch the IllegalStateException

