### PR TITLE
Add setFocusable to CoachMarkBuilder

### DIFF
--- a/cornedbeef/build.gradle
+++ b/cornedbeef/build.gradle
@@ -11,8 +11,8 @@ android {
     defaultConfig {
         minSdkVersion 12
         targetSdkVersion 26
-        versionCode 6
-        versionName "2.0.0"
+        versionCode 7
+        versionName "2.0.1"
     }
     buildTypes {
         release {

--- a/cornedbeef/src/main/java/com/swiftkey/cornedbeef/CoachMark.java
+++ b/cornedbeef/src/main/java/com/swiftkey/cornedbeef/CoachMark.java
@@ -222,6 +222,33 @@ public abstract class CoachMark {
     public boolean isShowing() {
         return mPopup.isShowing();
     }
+
+    /**
+     * Exposes the {@link PopupWindow#setFocusable(boolean)} method of {@link CoachMark#mPopup}
+     *
+     * Set whether the coach mark is focusable or not
+     * If we set the coach mark focusable, the behaviour changes as follows:
+     * For Explore-by-Touch mode
+     *   1. Outside of this coach mark becomes un-touchable
+     *   2. The coach mark can be dismissed by pressing the hardware back button
+     *   3. Focus can only be traversed through elements inside the coach mark area
+     * For Non Explore-by-Touch mode
+     *   1. Touching outside the coach mark will dismiss it
+     *      This doesn't apply to HighlightCoachMarks, as they always have touchable set to false
+     *   2. The coach mark can be dismissed by pressing the hardware back button
+     *
+     * @param focusable whether or not this coach mark can be focused
+     */
+    public void setFocusable(boolean focusable) {
+        mPopup.setFocusable(focusable);
+    }
+
+    /**
+     * Exposes the {@link PopupWindow#isFocusable()} method of {@link CoachMark#mPopup}
+     */
+    public boolean isFocusable() {
+        return mPopup.isFocusable();
+    }
     
     /**
      * Get the visible display size of the window this view is attached to

--- a/integrationtest/src/androidTest/java/com/swiftkey/cornedbeef/CoachMarkTestCase.java
+++ b/integrationtest/src/androidTest/java/com/swiftkey/cornedbeef/CoachMarkTestCase.java
@@ -282,6 +282,19 @@ public class CoachMarkTestCase extends ActivityInstrumentationTestCase2<SpamActi
         verify(mockOnDismissListener).onDismiss();
     }
 
+    /**
+     * Test coach mark focusable.
+     */
+    public void testViewsFocusable() {
+        mCoachMark = new TestCoachMark.TestCoachMarkBuilder(
+                mActivity, mAnchor, "spam spam spam").build();
+        showCoachMark(getInstrumentation(), mCoachMark);
+        mCoachMark.setFocusable(true);
+        assertTrue(mCoachMark.isFocusable());
+        mCoachMark.setFocusable(false);
+        assertFalse(mCoachMark.isFocusable());
+    }
+
     /*
      * HELPERS
      */


### PR DESCRIPTION
Provide a function to let user setFocusable from outside to meet different requirements.
Such as:
1. We want user can only do interaction with this coach mark, outside coach mark need become un-touchable.
2. In talkback mode, we want restrict focus inner this coach mark area, other than can go out and below of the coach mark.

Here are some pictures to show the behavior change:
<img width="443" alt="cornedbeef1" src="https://user-images.githubusercontent.com/25998953/41943994-9dd07c0c-795a-11e8-9a2b-0fa058bc80f8.png">
<img width="629" alt="cornedbeef2" src="https://user-images.githubusercontent.com/25998953/41943997-a0e41322-795a-11e8-8601-3ebf247c328c.png">

Pic 1 is the original screenshot before apply this change, the following pics are after apply this change.
Pic 2 is in non EbT mode, same UI as before, if we want quit the app by click hardware back button, it may need several click as each click dismiss one coach mark.
Pic 3 shows that the last coach mark get focus, in this time, focus can't move outside of that coach mark.
Pic 4 shows after perform one back button click, the last coach mark disappear.
Pic 5 shows after perform one more back button click, the second from last coach mark disappear.
