### PR TITLE
Update Artifactory Gradle plugin

### DIFF
--- a/cornedbeef/build.gradle
+++ b/cornedbeef/build.gradle
@@ -1,5 +1,5 @@
 plugins {
-    id "com.jfrog.artifactory" version "3.2.0"
+    id "com.jfrog.artifactory" version "4.9.8"
     id "maven-publish"
 }
 


### PR DESCRIPTION
3.2.0 does not work with Gradle 4.8+ and I did not notice when I updated Gradle. Using the latest version fixes the problems.

---

Publishing to Artifactory doesn't raise any errors now other than it doesn't have the right password. It couldn't find a method before the update.

@JPumphrey and @lachiemurray looked at previous related PRs but Jess isn't around and I don't think this is big enough to make Lachie review it.