### PR TITLE
Add option to change the color of bubble coach marks and the color and the stroke width of highlight coach marks

### DIFF
--- a/cornedbeef/build.gradle
+++ b/cornedbeef/build.gradle
@@ -11,8 +11,8 @@ android {
     defaultConfig {
         minSdkVersion 12
         targetSdkVersion 28
-        versionCode 9
-        versionName "2.0.3"
+        versionCode 10
+        versionName "2.0.4"
     }
     buildTypes {
         release {

--- a/cornedbeef/src/main/java/com/swiftkey/cornedbeef/CoachMarkUtils.java
+++ b/cornedbeef/src/main/java/com/swiftkey/cornedbeef/CoachMarkUtils.java
@@ -1,9 +1,15 @@
 package com.swiftkey.cornedbeef;
 
+import android.content.Context;
 import android.graphics.Point;
+import android.os.Build;
+
+import androidx.annotation.ColorInt;
+import androidx.annotation.ColorRes;
 
 /**
- * Utils for calculating the size and position of the coach mark popup and pointy mark
+ * Utils for calculating the size and position of the coach mark popup and pointy mark and for
+ * resolving colors.
  * 
  * @author lachie
  */
@@ -96,5 +102,21 @@ public class CoachMarkUtils {
             int arrowWidth, int anchorX, int popupX, int minMargin, int maxMargin) {
         int margin = (int) (target * anchorWidth) - (arrowWidth / 2) + anchorX - popupX;
         return margin < minMargin ? minMargin : (margin > maxMargin ? maxMargin : margin);
+    }
+
+    /**
+     * Resolve the given color resource ID to the int value of the color.
+     *
+     * @param context a context needed to resolve the color
+     * @param colorRes resource ID of the color to resolve
+     * @return the int value of the color with the given resource ID
+     */
+    public static @ColorInt int resolveColor(Context context, @ColorRes int colorRes) {
+        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.M) {
+            return context.getColor(colorRes);
+        } else {
+            //noinspection deprecation
+            return context.getResources().getColor(colorRes);
+        }
     }
 }

--- a/cornedbeef/src/main/java/com/swiftkey/cornedbeef/HighlightCoachMark.java
+++ b/cornedbeef/src/main/java/com/swiftkey/cornedbeef/HighlightCoachMark.java
@@ -1,11 +1,14 @@
 package com.swiftkey.cornedbeef;
 
 import android.content.Context;
+import android.graphics.drawable.GradientDrawable;
+import android.util.Log;
 import android.view.LayoutInflater;
 import android.view.View;
 import android.view.ViewGroup.LayoutParams;
 import android.widget.PopupWindow;
 
+import androidx.annotation.ColorInt;
 import androidx.annotation.LayoutRes;
 
 /**
@@ -14,9 +17,17 @@ import androidx.annotation.LayoutRes;
  * @author lachie
  */
 public class HighlightCoachMark extends InternallyAnchoredCoachMark {
+    private View mView;
 
     protected HighlightCoachMark(HighlightCoachMarkBuilder builder) {
         super(builder);
+
+        try {
+            ((GradientDrawable) mView.getBackground().mutate()).setStroke(
+                    builder.strokeWidth, builder.highlightColor);
+        } catch (Exception e) {
+            Log.e("HighlightCoachMark", "Could not change the coach mark color and stroke width");
+        }
     }
 
     @Override
@@ -31,7 +42,8 @@ public class HighlightCoachMark extends InternallyAnchoredCoachMark {
     }
 
     protected View createContentView(View content) {
-        return LayoutInflater.from(mContext).inflate(R.layout.highlight_coach_mark, null);
+        mView = LayoutInflater.from(mContext).inflate(R.layout.highlight_coach_mark, null);
+        return mView;
     }
 
     @Override
@@ -46,20 +58,57 @@ public class HighlightCoachMark extends InternallyAnchoredCoachMark {
     
     public static class HighlightCoachMarkBuilder extends InternallyAnchoredCoachMarkBuilder {
 
+        // Optional parameters with default values
+        @ColorInt int highlightColor;
+        int strokeWidth;
+
         public HighlightCoachMarkBuilder(Context context, View anchor) {
             super(context, anchor, new String());
+            setDefaultValues(context);
         }
 
         public HighlightCoachMarkBuilder(Context context, View anchor, String message) {
             super(context, anchor, message);
+            setDefaultValues(context);
         }
 
         public HighlightCoachMarkBuilder(Context context, View anchor, View content) {
             super(context, anchor, content);
+            setDefaultValues(context);
         }
 
         public HighlightCoachMarkBuilder(Context context, View anchor, @LayoutRes int contentResId) {
             super(context, anchor, contentResId);
+            setDefaultValues(context);
+        }
+
+        private void setDefaultValues(final Context context) {
+            this.highlightColor = CoachMarkUtils.resolveColor(context, R.color.default_colour);
+            this.strokeWidth = (int) context.getResources().getDimension(
+                    R.dimen.highlight_coach_mark_stroke_width);
+        }
+
+        /**
+         * Set the coach mark's highlight color.
+         *
+         * @param highlightColor
+         *      new highlight color
+         */
+        public HighlightCoachMark.HighlightCoachMarkBuilder setHighlightColor(
+                @ColorInt int highlightColor) {
+            this.highlightColor = highlightColor;
+            return this;
+        }
+
+        /**
+         * Set the coach mark's stroke width.
+         *
+         * @param strokeWidth
+         *      new stroke width
+         */
+        public HighlightCoachMark.HighlightCoachMarkBuilder setStrokeWidth(int strokeWidth) {
+            this.strokeWidth = strokeWidth;
+            return this;
         }
         
         @Override

--- a/cornedbeef/src/main/res/drawable/highlight_coach_mark_bg.xml
+++ b/cornedbeef/src/main/res/drawable/highlight_coach_mark_bg.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <shape xmlns:android="http://schemas.android.com/apk/res/android" android:shape="rectangle" >
    <solid android:color="@android:color/transparent" />
-   <stroke android:width="2dp" android:color="@color/default_colour"/>
+   <stroke android:width="@dimen/highlight_coach_mark_stroke_width" android:color="@color/default_colour"/>
    <corners android:radius="@dimen/coach_mark_border_radius"/>
 </shape>

--- a/cornedbeef/src/main/res/values/dimens.xml
+++ b/cornedbeef/src/main/res/values/dimens.xml
@@ -4,4 +4,5 @@
     <dimen name="punchhole_coach_mark_gap">2dp</dimen>
     <dimen name="punchhole_coach_mark_horizontal_padding">24dp</dimen>
     <dimen name="punchhole_coach_mark_vertical_padding">20dp</dimen>
+    <dimen name="highlight_coach_mark_stroke_width">2dp</dimen>
 </resources>

--- a/integrationtest/src/androidTest/java/com/swiftkey/cornedbeef/BubbleCoachMarkTestCase.java
+++ b/integrationtest/src/androidTest/java/com/swiftkey/cornedbeef/BubbleCoachMarkTestCase.java
@@ -1,5 +1,8 @@
 package com.swiftkey.cornedbeef;
 
+import android.graphics.Color;
+import android.graphics.drawable.GradientDrawable;
+import android.os.Build;
 import android.os.SystemClock;
 import android.util.TypedValue;
 import android.view.MotionEvent;
@@ -7,8 +10,12 @@ import android.view.View;
 import android.view.ViewGroup;
 import android.view.ViewGroup.MarginLayoutParams;
 import android.view.WindowManager;
+import android.widget.ImageView;
+import android.widget.LinearLayout;
 import android.widget.TextView;
 
+import androidx.annotation.ColorInt;
+import androidx.test.filters.SdkSuppress;
 import androidx.test.rule.ActivityTestRule;
 
 import com.swiftkey.cornedbeef.test.R;
@@ -376,5 +383,33 @@ public class BubbleCoachMarkTestCase {
 
         assertEquals(paddingInPx, contentPos[0]);
         assertEquals(screenWidth - paddingInPx, contentPos[0] + mCoachMark.getContentView().getWidth());
+    }
+
+    /**
+     * Verify that the coach mark bubble color is set correctly
+     */
+    @Test
+    @SdkSuppress(minSdkVersion = Build.VERSION_CODES.LOLLIPOP)
+    public void testSetBubbleColor() {
+        final @ColorInt int color = Color.RED;
+        mCoachMark = new BubbleCoachMark.BubbleCoachMarkBuilder(
+                mActivity,
+                mAnchor,
+                "spam spam spam")
+                .setBubbleColor(color)
+                .build();
+
+        showCoachMark(getInstrumentation(), mCoachMark);
+
+        assertTrue(mCoachMark.isShowing());
+        final ImageView topArrow = mCoachMark.getContentView().findViewById(R.id.top_arrow);
+        final ImageView bottomArrow = mCoachMark.getContentView().findViewById(R.id.bottom_arrow);
+        final LinearLayout contentHolder = mCoachMark.getContentView().findViewById(R.id.coach_mark_content);
+        assertEquals(color, topArrow.getImageTintList().getDefaultColor());
+        assertEquals(color, bottomArrow.getImageTintList().getDefaultColor());
+        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.N) {
+            // getColor was added in API 24
+            assertEquals(color, ((GradientDrawable) contentHolder.getBackground()).getColor().getDefaultColor());
+        }
     }
 }

--- a/integrationtest/src/androidTest/java/com/swiftkey/cornedbeef/HighlightCoachMarkTestCase.java
+++ b/integrationtest/src/androidTest/java/com/swiftkey/cornedbeef/HighlightCoachMarkTestCase.java
@@ -1,0 +1,81 @@
+package com.swiftkey.cornedbeef;
+
+import android.graphics.Color;
+import android.view.View;
+import android.view.WindowManager;
+
+import androidx.test.rule.ActivityTestRule;
+
+import com.swiftkey.cornedbeef.test.R;
+import com.swiftkey.cornedbeef.test.SpamActivity;
+
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Rule;
+import org.junit.Test;
+
+import static androidx.test.platform.app.InstrumentationRegistry.getInstrumentation;
+import static com.swiftkey.cornedbeef.TestHelper.dismissCoachMark;
+import static com.swiftkey.cornedbeef.TestHelper.showCoachMark;
+import static com.swiftkey.cornedbeef.TestHelper.waitUntilStatusBarHidden;
+import static org.junit.Assert.assertTrue;
+
+public class HighlightCoachMarkTestCase {
+
+    private SpamActivity mActivity;
+    private CoachMark mCoachMark;
+    private View mAnchor;
+
+    @Rule
+    public ActivityTestRule<SpamActivity> mActivityRule =
+            new ActivityTestRule<>(SpamActivity.class, false, true);
+
+    @Before
+    public void setUp() {
+        mActivity = mActivityRule.getActivity();
+        
+        getInstrumentation().runOnMainSync(new Runnable() {
+            
+            @Override
+            public void run() {
+                mActivity.getWindow().setFlags(
+                        WindowManager.LayoutParams.FLAG_FULLSCREEN,
+                        WindowManager.LayoutParams.FLAG_FULLSCREEN);
+                mActivity.setContentView(R.layout.coach_mark_test_activity);
+                mAnchor = mActivity.findViewById(R.id.coach_mark_test_target_wide);
+            }
+        });
+        getInstrumentation().waitForIdleSync();
+        waitUntilStatusBarHidden(mActivity);
+        
+        mCoachMark = new HighlightCoachMark.HighlightCoachMarkBuilder(
+                mActivity, mAnchor, "spam spam spam").build();
+    }
+
+    @After
+    public void tearDown() {
+        dismissCoachMark(getInstrumentation(), mCoachMark);
+        mCoachMark = null;
+        mAnchor = null;
+        mActivity = null;
+    }
+
+    /**
+     * Verify that we can show the coach mark
+     */
+    @Test
+    public void testShowCoachMark() {
+        mCoachMark = new HighlightCoachMark.HighlightCoachMarkBuilder(
+                mActivity,
+                mAnchor,
+                "spam spam spam")
+                .setHighlightColor(Color.RED)
+                .setStrokeWidth(20)
+                .build();
+
+        showCoachMark(getInstrumentation(), mCoachMark);
+
+        assertTrue(mCoachMark.isShowing());
+        // it is not possible to get information about the stroke so our testing is limited
+    }
+}


### PR DESCRIPTION
A while ago we updated the default colour of coach marks but we didn't provide any options to change it (either back to how it was or to any other value). Here we add a way of changing the colour of bubble coach marks and the colour and stroke width of highlight coach marks.

I think this is still small enough to be a trivial patch contribution under https://docs.opensource.microsoft.com/policies/de-minimis.html

I've taken screenshots by setting break points in the tests. Here are some:

- In Jelly Bean:
![cm-all-jb](https://user-images.githubusercontent.com/2212284/65984473-c5115780-e477-11e9-8c34-a0367bfd3a71.png)
![cm-highlight-red-jb](https://user-images.githubusercontent.com/2212284/65984475-c5115780-e477-11e9-9820-c47f89a22bd7.png)

- In Lollipop:
![cm-all-l](https://user-images.githubusercontent.com/2212284/65984495-cd699280-e477-11e9-8b3a-79a269359de4.png)
![cm-bubble-red-l](https://user-images.githubusercontent.com/2212284/65984496-cd699280-e477-11e9-99f2-18373db21010.png)
![cm-highlight-red-l](https://user-images.githubusercontent.com/2212284/65984497-cd699280-e477-11e9-8560-35d79633172a.png)

- In Pie:
![cm-all-p](https://user-images.githubusercontent.com/2212284/65984510-d3f80a00-e477-11e9-8d3e-fdbf30dbc654.png)
![cm-bubble-red-p](https://user-images.githubusercontent.com/2212284/65984512-d3f80a00-e477-11e9-8fea-7179133770fb.png)
![cm-highlight-red-p](https://user-images.githubusercontent.com/2212284/65984513-d490a080-e477-11e9-8d8b-851104eb8825.png)

As usual, I can't add @lachiemurray as a reviewer so I have to tag him here.