### PR TITLE
Add option to change the text color of coach marks

### DIFF
--- a/cornedbeef/src/main/java/com/swiftkey/cornedbeef/CoachMark.java
+++ b/cornedbeef/src/main/java/com/swiftkey/cornedbeef/CoachMark.java
@@ -16,6 +16,7 @@ import android.view.ViewTreeObserver.OnPreDrawListener;
 import android.widget.PopupWindow;
 import android.widget.TextView;
 
+import androidx.annotation.ColorInt;
 import androidx.annotation.IntDef;
 import androidx.annotation.LayoutRes;
 import androidx.annotation.StyleRes;
@@ -481,6 +482,21 @@ public abstract class CoachMark {
         public CoachMarkBuilder setDismissOnAnchorDetach(boolean shouldDismissOnAnchorDetach) {
             this.shouldDismissOnAnchorDetach = shouldDismissOnAnchorDetach;
             return this;
+        }
+
+        /**
+         * Set the coach mark's text color.
+         *
+         * @param textColor new text color
+         */
+        public CoachMarkBuilder setTextColor(@ColorInt int textColor) {
+            if (this.content instanceof TextView) {
+                ((TextView) this.content).setTextColor(textColor);
+                return this;
+            } else {
+                throw new IllegalStateException(
+                        "Can't set a text color in a CoachMark whose content is not a TextView");
+            }
         }
 
         public abstract CoachMark build();

--- a/integrationtest/src/androidTest/java/com/swiftkey/cornedbeef/BubbleCoachMarkTestCase.java
+++ b/integrationtest/src/androidTest/java/com/swiftkey/cornedbeef/BubbleCoachMarkTestCase.java
@@ -412,4 +412,60 @@ public class BubbleCoachMarkTestCase {
             assertEquals(color, ((GradientDrawable) contentHolder.getBackground()).getColor().getDefaultColor());
         }
     }
+
+    /**
+     * Verify that the coach mark text color is set correctly
+     */
+    @Test
+    public void testSetTextColor() {
+        final @ColorInt int color = Color.RED;
+        mCoachMark = new BubbleCoachMark.BubbleCoachMarkBuilder(
+                mActivity,
+                mAnchor,
+                "spam spam spam")
+                .setTextColor(color)
+                .build();
+
+        showCoachMark(getInstrumentation(), mCoachMark);
+
+        assertTrue(mCoachMark.isShowing());
+
+        final ViewGroup content = mCoachMark.getContentView().findViewById(R.id.coach_mark_content);
+        final TextView tv = (TextView) content.getChildAt(0);
+        assertEquals(color, tv.getCurrentTextColor());
+    }
+
+    /**
+     * Verify that setting the coach mark text color on a non-text coach mark throws exception
+     */
+    @Test(expected = IllegalStateException.class)
+    public void testSetTextColorOnNonTextCoachMark() {
+        mCoachMark = new BubbleCoachMark.BubbleCoachMarkBuilder(
+                mActivity,
+                mAnchor,
+                new ImageView(mActivity))
+                .setTextColor(Color.RED)
+                .build();
+    }
+
+    /**
+     * Verify that a non-text coach mark is shown correctly
+     */
+    @Test
+    public void testNonTextCoachMark() {
+        final ImageView imageView = new ImageView(mActivity);
+        imageView.setImageResource(R.drawable.ic_pointy_mark_up);
+        mCoachMark = new BubbleCoachMark.BubbleCoachMarkBuilder(
+                mActivity,
+                mAnchor,
+                imageView)
+                .build();
+
+        showCoachMark(getInstrumentation(), mCoachMark);
+
+        assertTrue(mCoachMark.isShowing());
+
+        final ViewGroup content = mCoachMark.getContentView().findViewById(R.id.coach_mark_content);
+        assertTrue(content.getChildAt(0) instanceof ImageView);
+    }
 }

--- a/integrationtest/src/androidTest/java/com/swiftkey/cornedbeef/HighlightCoachMarkTestCase.java
+++ b/integrationtest/src/androidTest/java/com/swiftkey/cornedbeef/HighlightCoachMarkTestCase.java
@@ -3,6 +3,7 @@ package com.swiftkey.cornedbeef;
 import android.graphics.Color;
 import android.view.View;
 import android.view.WindowManager;
+import android.widget.ImageView;
 
 import androidx.test.rule.ActivityTestRule;
 
@@ -71,11 +72,51 @@ public class HighlightCoachMarkTestCase {
                 "spam spam spam")
                 .setHighlightColor(Color.RED)
                 .setStrokeWidth(20)
+                .setTextColor(Color.RED)
                 .build();
 
         showCoachMark(getInstrumentation(), mCoachMark);
 
         assertTrue(mCoachMark.isShowing());
-        // it is not possible to get information about the stroke so our testing is limited
+        // Note: it is not possible to get information about the stroke so our testing is limited
+        // Note: we're just testing that setting a text color won't provoke a crash because
+        //       highlight coach marks have no text
+    }
+
+    /**
+     * Verify that setting the coach mark text color on a non-text coach mark throws exception
+     */
+    @Test(expected = IllegalStateException.class)
+    public void testSetTextColorOnNonTextCoachMark() {
+        mCoachMark = new HighlightCoachMark.HighlightCoachMarkBuilder(
+                mActivity,
+                mAnchor,
+                new ImageView(mActivity))
+                .setHighlightColor(Color.RED)
+                .setStrokeWidth(20)
+                .setTextColor(Color.RED)
+                .build();
+    }
+
+    /**
+     * Verify that a non-text coach mark is shown correctly
+     */
+    @Test
+    public void testNonTextCoachMark() {
+        final ImageView imageView = new ImageView(mActivity);
+        imageView.setImageResource(R.drawable.ic_pointy_mark_up);
+        mCoachMark = new HighlightCoachMark.HighlightCoachMarkBuilder(
+                mActivity,
+                mAnchor,
+                imageView)
+                .setHighlightColor(Color.RED)
+                .setStrokeWidth(20)
+                .build();
+
+        showCoachMark(getInstrumentation(), mCoachMark);
+
+        assertTrue(mCoachMark.isShowing());
+        // Note: we're just testing that this won't provoke a crash because highlight coach marks
+        //       have no content
     }
 }

--- a/integrationtest/src/androidTest/java/com/swiftkey/cornedbeef/LayeredCoachMarkTestCase.java
+++ b/integrationtest/src/androidTest/java/com/swiftkey/cornedbeef/LayeredCoachMarkTestCase.java
@@ -1,10 +1,13 @@
 package com.swiftkey.cornedbeef;
 
+import android.graphics.Color;
 import android.view.View;
 import android.view.ViewGroup;
 import android.view.WindowManager;
+import android.widget.ImageView;
 import android.widget.TextView;
 
+import androidx.annotation.ColorInt;
 import androidx.test.rule.ActivityTestRule;
 
 import com.swiftkey.cornedbeef.test.R;
@@ -51,9 +54,6 @@ public class LayeredCoachMarkTestCase {
         });
         getInstrumentation().waitForIdleSync();
         waitUntilStatusBarHidden(mActivity);
-
-        mCoachMark = new LayeredCoachMark.LayeredCoachMarkBuilder(mActivity, mAnchor, MESSAGE)
-                .build();
     }
 
     @After
@@ -69,6 +69,9 @@ public class LayeredCoachMarkTestCase {
      */
     @Test
     public void testViewsCreatedAndVisible() {
+        mCoachMark = new LayeredCoachMark.LayeredCoachMarkBuilder(mActivity, mAnchor, MESSAGE)
+                .build();
+
         showCoachMark(getInstrumentation(), mCoachMark);
 
         final View container = mCoachMark.getContentView();
@@ -84,5 +87,53 @@ public class LayeredCoachMarkTestCase {
         // Check the visibility
         assertEquals(MESSAGE, tv.getText());
         assertTrue(mCoachMark.isShowing());
+    }
+
+    /**
+     * Test that the coach mark text color is set correctly
+     */
+    @Test
+    public void testSetTextColor() {
+        final @ColorInt int color = Color.RED;
+        mCoachMark = new LayeredCoachMark.LayeredCoachMarkBuilder(mActivity, mAnchor, MESSAGE)
+                .setTextColor(color)
+                .build();
+
+        showCoachMark(getInstrumentation(), mCoachMark);
+
+        final TextView tv = (TextView) ((ViewGroup) mCoachMark.getContentView()).getChildAt(0);
+
+        // Check the text, text color and visibility
+        assertTrue(mCoachMark.isShowing());
+        assertEquals(MESSAGE, tv.getText());
+        assertEquals(color, tv.getCurrentTextColor());
+    }
+
+    /**
+     * Verify that setting the coach mark text color on a non-text coach mark throws exception
+     */
+    @Test(expected = IllegalStateException.class)
+    public void testSetTextColorOnNonTextCoachMark() {
+        mCoachMark = new LayeredCoachMark.LayeredCoachMarkBuilder(mActivity, mAnchor, new ImageView(mActivity))
+                .setTextColor(Color.RED)
+                .build();
+    }
+
+    /**
+     * Verify that a non-text coach mark is shown correctly
+     */
+    @Test
+    public void testNonTextCoachMark() {
+        final ImageView imageView = new ImageView(mActivity);
+        imageView.setImageResource(R.drawable.ic_pointy_mark_up);
+        mCoachMark = new LayeredCoachMark.LayeredCoachMarkBuilder(mActivity, mAnchor, imageView)
+                .build();
+
+        showCoachMark(getInstrumentation(), mCoachMark);
+
+        assertTrue(mCoachMark.isShowing());
+
+        final ViewGroup content = mCoachMark.getContentView().findViewById(R.id.coach_mark_content);
+        assertTrue(content.getChildAt(0) instanceof ImageView);
     }
 }

--- a/integrationtest/src/androidTest/java/com/swiftkey/cornedbeef/PunchHoleCoachMarkTestCase.java
+++ b/integrationtest/src/androidTest/java/com/swiftkey/cornedbeef/PunchHoleCoachMarkTestCase.java
@@ -6,9 +6,12 @@ import android.graphics.drawable.ColorDrawable;
 import android.util.TypedValue;
 import android.view.LayoutInflater;
 import android.view.View;
+import android.view.ViewGroup;
 import android.view.WindowManager;
+import android.widget.ImageView;
 import android.widget.TextView;
 
+import androidx.annotation.ColorInt;
 import androidx.test.rule.ActivityTestRule;
 
 import com.swiftkey.cornedbeef.test.R;
@@ -39,6 +42,7 @@ import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertThat;
+import static org.junit.Assert.assertTrue;
 import static org.mockito.Matchers.any;
 import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.times;
@@ -304,6 +308,71 @@ public class PunchHoleCoachMarkTestCase {
 
         assertEquals(contentWidth, mTextView.getLayoutParams().width);
         assertEquals(contentHeight, mTextView.getLayoutParams().height);
+    }
+
+    /**
+     * Test that the coach mark text color is set correctly
+     */
+    @Test
+    public void testSetTextColor() {
+        final @ColorInt int color = Color.RED;
+
+        mCoachMark = new PunchHoleCoachMarkBuilder(mActivity, mAnchor, mTextView)
+                .setTargetView(mTargetView)
+                .setHorizontalTranslationDuration(1000)
+                .setOnTargetClickListener(mMockTargetClickListener)
+                .setOnGlobalClickListener(mMockCoachMarkClickListener)
+                .setOverlayColor(OVERLAY_COLOR)
+                .setContentLayoutParams(MATCH_PARENT, MATCH_PARENT, POSITION_CONTENT_AUTOMATICALLY)
+                .setPunchHolePadding(PADDING)
+                .setTextColor(color)
+                .build();
+
+        showCoachMark(getInstrumentation(), mCoachMark);
+
+        assertEquals(color, mTextView.getCurrentTextColor());
+    }
+
+    /**
+     * Verify that setting the coach mark text color on a non-text coach mark throws exception
+     */
+    @Test(expected = IllegalStateException.class)
+    public void testSetTextColorOnNonTextCoachMark() {
+        mCoachMark = new PunchHoleCoachMarkBuilder(mActivity, mAnchor, new ImageView(mActivity))
+                .setTargetView(mTargetView)
+                .setHorizontalTranslationDuration(1000)
+                .setOnTargetClickListener(mMockTargetClickListener)
+                .setOnGlobalClickListener(mMockCoachMarkClickListener)
+                .setOverlayColor(OVERLAY_COLOR)
+                .setContentLayoutParams(MATCH_PARENT, MATCH_PARENT, POSITION_CONTENT_AUTOMATICALLY)
+                .setPunchHolePadding(PADDING)
+                .setTextColor(Color.RED)
+                .build();
+    }
+
+    /**
+     * Verify that a non-text coach mark is shown correctly
+     */
+    @Test
+    public void testNonTextCoachMark() {
+        final ImageView imageView = new ImageView(mActivity);
+        imageView.setImageResource(R.drawable.ic_pointy_mark_up);
+        mCoachMark = new PunchHoleCoachMarkBuilder(mActivity, mAnchor, imageView)
+                .setTargetView(mTargetView)
+                .setHorizontalTranslationDuration(1000)
+                .setOnTargetClickListener(mMockTargetClickListener)
+                .setOnGlobalClickListener(mMockCoachMarkClickListener)
+                .setOverlayColor(OVERLAY_COLOR)
+                .setContentLayoutParams(MATCH_PARENT, MATCH_PARENT, POSITION_CONTENT_AUTOMATICALLY)
+                .setPunchHolePadding(PADDING)
+                .build();
+
+        showCoachMark(getInstrumentation(), mCoachMark);
+
+        assertTrue(mCoachMark.isShowing());
+
+        final ViewGroup content = (ViewGroup) mCoachMark.getContentView();
+        assertTrue(content.getChildAt(0) instanceof ImageView);
     }
 
     /**

--- a/integrationtest/src/androidTest/java/com/swiftkey/cornedbeef/TestHelper.java
+++ b/integrationtest/src/androidTest/java/com/swiftkey/cornedbeef/TestHelper.java
@@ -36,7 +36,9 @@ public final class TestHelper {
         instrumentation.runOnMainSync(new Runnable() {
             @Override
             public void run() {
-                coachMark.dismiss();
+                if (coachMark != null) {
+                    coachMark.dismiss();
+                }
             }
         });
         instrumentation.waitForIdleSync();


### PR DESCRIPTION
We add the option at the CoachMark level so all coach marks can benefit from it. Note that HighlightCoachMarks have no text, but it is possible to set a text color in their builder which has no effect, the same way that it is possible to set a text in their builder which has no effect.

I am planning another minor update next week. I'll update the version code and version number and I'll make a release when both changes are finished.

I think this is small enough to be a trivial patch contribution under https://docs.opensource.microsoft.com/content/policies/small-code-exception.html

Here are some screenshots from the tests:

Bubble coach mark:
![2645-bubble](https://user-images.githubusercontent.com/2212284/96139643-f4fe9200-0ef6-11eb-8f6e-b99a274d1bf4.png)

Layered coach mark:
![2645-layered](https://user-images.githubusercontent.com/2212284/96139655-f7f98280-0ef6-11eb-8382-76f67ae3c9c1.png)

Punch hole coach mark:
![2645-punchhole](https://user-images.githubusercontent.com/2212284/96139669-fb8d0980-0ef6-11eb-91f4-5d659c186867.png)