### PR TITLE
Migrate away from JFrog

### DIFF
--- a/azure/publish.yml
+++ b/azure/publish.yml
@@ -2,10 +2,8 @@ name: $(BuildDefinitionName) $(SourceBranchName) $(Date:yyyy-MM-dd)$(Rev:.rr)
 
 # Triggers are overriden in ADO UI. Run this job manually on ADO. Requires the following
 # variables to be set in UI (when creating a new pipeline from this file)
-# artifactoryUser
-# artifactoryPassword
-# artifactoryRepository
-# artifactoryUrl
+# publishUser
+# publishUrl
 trigger: none
 pr: none
 
@@ -16,16 +14,15 @@ steps:
 - task: Gradle@2
   inputs:
     gradleWrapperFile: 'gradlew'
-    tasks: 'clean assembleRelease artifactoryPublish'
+    tasks: 'clean assembleRelease publish'
     options: '
       --continue 
       --stacktrace 
       --no-daemon 
-      -Partifactory_user=$(artifactoryUser)
-      -Partifactory_pass=$(artifactoryPassword)
-      -Partifactory_repo_key=$(artifactoryRepository)
-      -Partifactory_url=$(artifactoryUrl)'
+      -Ppublish_user=$(publishUser)
+      -Ppublish_pass=$(System.AccessToken)
+      -Ppublish_url=$(publishUrl)'
     publishJUnitResults: false
     javaHomeOption: 'JDKVersion'
     sonarQubeRunAnalysis: false
-  displayName: 'Publish to $(artifactoryRepository)'
+  displayName: 'Publish to artifact feed'

--- a/cornedbeef/build.gradle
+++ b/cornedbeef/build.gradle
@@ -1,5 +1,4 @@
 plugins {
-    id "com.jfrog.artifactory" version "4.9.8"
     id "maven-publish"
 }
 
@@ -30,39 +29,29 @@ dependencies {
     testImplementation 'org.mockito:mockito-core:2.28.2'
 }
 
-publishing.publications {
-    aar(MavenPublication) {
-        groupId "TouchType"
-        version = android.defaultConfig.versionName
-        artifactId project.getName()
+publishing {
+    repositories {
 
-        // Tell maven to prepare the generated "*.aar" file for publishing
-        artifact("$buildDir/outputs/aar/${project.getName()}-release.aar")
-    }
-}
+        def user=project.properties['publish_user'] ?: "admin"
+        def pass=project.properties['publish_pass'] ?: "password"
+        def url=project.properties['publish_url'] ?: "http://localhost:8081"
 
-artifactory {
-
-    // artifactory properties with local defaults
-    def user=project.properties['artifactory_user'] ?: "admin"
-    def pass=project.properties['artifactory_pass'] ?: "password"
-    def key=project.properties['artifactory_repo_key'] ?: "libs-release-local"
-    def url=project.properties['artifactory_url'] ?: "http://localhost:8081/artifactory"
-
-    contextUrl = url
-    publish {
-        repository {
-            // The Artifactory repository key to publish to
-            repoKey = key
-            username = user
-            password = pass
+        maven {
+            setUrl(url)
+            credentials {
+                username = user
+                password = pass
+            }
         }
-        defaults {
-            // Tell the Artifactory Plugin which artifacts should be published to Artifactory.
-            publications('aar')
-            publishArtifacts = true
+    }
+
+    publications {
+        aar(MavenPublication) {
+            groupId "TouchType"
+            version = android.defaultConfig.versionName
+            artifactId project.getName()
+
+            artifact("$buildDir/outputs/aar/${project.getName()}-release.aar")
         }
     }
 }
-
-


### PR DESCRIPTION
We're migrating away from JFrog for our artifact management, I'm cleaning up the repo to use a standard maven publication target.